### PR TITLE
Switch mailer from ssmtp to msmtp

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -33,8 +33,8 @@ RUN docker-php-source extract \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 
-RUN apt-get install -y ssmtp \
-    && echo "mailhub=mailhog:1025" >> /etc/ssmtp/ssmtp.conf
+RUN apt-get install -y msmtp \
+    && printf "account default\nhost mailhog\nport 1025\nauto_from on\n" > /etc/msmtprc
 
 COPY ./mailhog.ini /usr/local/etc/php/conf.d/mailhog.ini
 ARG BUILD_DATE

--- a/dev/mailhog.ini
+++ b/dev/mailhog.ini
@@ -1,2 +1,2 @@
 [mail function]
-sendmail_path = "/usr/sbin/ssmtp -t"
+sendmail_path = "/usr/bin/msmtp -t"

--- a/generate_dockerfiles.php
+++ b/generate_dockerfiles.php
@@ -66,8 +66,8 @@ LABEL org.label-schema.version=$BUILD_VERSION
 LBL;
 
 $mailTemplate = <<<MAIL
-RUN apt-get install -y ssmtp \
-    && echo "mailhub=mailhog:1025" >> /etc/ssmtp/ssmtp.conf
+RUN apt-get install -y msmtp \
+    && printf "account default\\nhost mailhog\\nport 1025\\nauto_from on\\n" > /etc/msmtprc
 
 COPY ./mailhog.ini /usr/local/etc/php/conf.d/mailhog.ini
 MAIL;

--- a/mailhog.ini
+++ b/mailhog.ini
@@ -1,2 +1,2 @@
 [mail function]
-sendmail_path = "/usr/sbin/ssmtp -t"
+sendmail_path = "/usr/bin/msmtp -t"

--- a/xdebug/Dockerfile
+++ b/xdebug/Dockerfile
@@ -33,8 +33,8 @@ RUN docker-php-source extract \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 
-RUN apt-get install -y ssmtp \
-    && echo "mailhub=mailhog:1025" >> /etc/ssmtp/ssmtp.conf
+RUN apt-get install -y msmtp \
+    && printf "account default\nhost mailhog\nport 1025\nauto_from on\n" > /etc/msmtprc
 
 COPY ./mailhog.ini /usr/local/etc/php/conf.d/mailhog.ini
 RUN pecl install xdebug-2.7.2 \

--- a/xdebug/mailhog.ini
+++ b/xdebug/mailhog.ini
@@ -1,2 +1,2 @@
 [mail function]
-sendmail_path = "/usr/sbin/ssmtp -t"
+sendmail_path = "/usr/bin/msmtp -t"


### PR DESCRIPTION
In the new Debian version (buster) the lightweight SMTP client ssmtp is
no longer included because it's unmaintained.

This patch uses the recommended alternative, msmtp, configuring it to be
used in conjunction with the "mailhog" container.