### PR TITLE
Update dependencies, Release version 1.1

### DIFF
--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,43 +1,41 @@
 #
 # This is an automatically generated Dockerfile, do not change this!
 #
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/doctrine_proxies \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
-    && curl -Ls -o konto_check-6.08.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.08/konto_check-6.08.zip/download  \
+    && curl -Ls -o konto_check-6.11.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.11/konto_check-6.11.zip/download  \
     && unzip konto_check-*.zip \
-    && cd konto_check-6.08 \
+    && cd konto_check-6.11 \
     && cp blz.lut2f /etc/blz.lut \
     && unzip php.zip \
     && cd php \
-    && docker-php-ext-configure /tmp/konto_check-6.08/php \
-    && docker-php-ext-install /tmp/konto_check-6.08/php \
+    && docker-php-ext-configure /tmp/konto_check-6.11/php \
+    && docker-php-ext-install /tmp/konto_check-6.11/php \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 
 RUN apt-get install -y git subversion mercurial bash patch make zip libzip-dev \
-    && docker-php-ext-configure zip --with-libzip \
     && docker-php-ext-install -j$(nproc) zip
 
-COPY --from=composer:1.8 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.1 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,35 +1,34 @@
 #
 # This is an automatically generated Dockerfile, do not change this!
 #
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/doctrine_proxies \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
-    && curl -Ls -o konto_check-6.08.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.08/konto_check-6.08.zip/download  \
+    && curl -Ls -o konto_check-6.11.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.11/konto_check-6.11.zip/download  \
     && unzip konto_check-*.zip \
-    && cd konto_check-6.08 \
+    && cd konto_check-6.11 \
     && cp blz.lut2f /etc/blz.lut \
     && unzip php.zip \
     && cd php \
-    && docker-php-ext-configure /tmp/konto_check-6.08/php \
-    && docker-php-ext-install /tmp/konto_check-6.08/php \
+    && docker-php-ext-configure /tmp/konto_check-6.11/php \
+    && docker-php-ext-install /tmp/konto_check-6.11/php \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 

--- a/generate_dockerfiles.php
+++ b/generate_dockerfiles.php
@@ -1,11 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-$PHP_VERSION = "7.3";
-$XDEBUG_VERSION = "2.7.2";
-$KONTOCHECK_VERSION = "6.08";
-$COMPOSER_VERSION = "1.8";
-$PHPSTAN_VERSION = "^0.11";
+$PHP_VERSION = "7.4";
+$XDEBUG_VERSION = "2.9.3";
+$KONTOCHECK_VERSION = "6.11";
+$COMPOSER_VERSION = "1.10.1";
+$PHPSTAN_VERSION = "^0.12";
 
 $headerTemplate = <<<HD
 #
@@ -21,17 +21,16 @@ RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
@@ -81,7 +80,6 @@ XDEBUG;
 
 $composerTemplate = <<<COMPOSER
 RUN apt-get install -y git subversion mercurial bash patch make zip libzip-dev \
-    && docker-php-ext-configure zip --with-libzip \
     && docker-php-ext-install -j$(nproc) zip
 
 COPY --from=composer:$COMPOSER_VERSION /usr/bin/composer /usr/bin/composer

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,35 +1,34 @@
 #
 # This is an automatically generated Dockerfile, do not change this!
 #
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/doctrine_proxies \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
-    && curl -Ls -o konto_check-6.08.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.08/konto_check-6.08.zip/download  \
+    && curl -Ls -o konto_check-6.11.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.11/konto_check-6.11.zip/download  \
     && unzip konto_check-*.zip \
-    && cd konto_check-6.08 \
+    && cd konto_check-6.11 \
     && cp blz.lut2f /etc/blz.lut \
     && unzip php.zip \
     && cd php \
-    && docker-php-ext-configure /tmp/konto_check-6.08/php \
-    && docker-php-ext-install /tmp/konto_check-6.08/php \
+    && docker-php-ext-configure /tmp/konto_check-6.11/php \
+    && docker-php-ext-install /tmp/konto_check-6.11/php \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 

--- a/stan/Dockerfile
+++ b/stan/Dockerfile
@@ -1,43 +1,41 @@
 #
 # This is an automatically generated Dockerfile, do not change this!
 #
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/doctrine_proxies \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
-    && curl -Ls -o konto_check-6.08.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.08/konto_check-6.08.zip/download  \
+    && curl -Ls -o konto_check-6.11.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.11/konto_check-6.11.zip/download  \
     && unzip konto_check-*.zip \
-    && cd konto_check-6.08 \
+    && cd konto_check-6.11 \
     && cp blz.lut2f /etc/blz.lut \
     && unzip php.zip \
     && cd php \
-    && docker-php-ext-configure /tmp/konto_check-6.08/php \
-    && docker-php-ext-install /tmp/konto_check-6.08/php \
+    && docker-php-ext-configure /tmp/konto_check-6.11/php \
+    && docker-php-ext-install /tmp/konto_check-6.11/php \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 
 RUN apt-get install -y git subversion mercurial bash patch make zip libzip-dev \
-    && docker-php-ext-configure zip --with-libzip \
     && docker-php-ext-install -j$(nproc) zip
 
-COPY --from=composer:1.8 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.1 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
@@ -45,7 +43,7 @@ ENV COMPOSER_HOME /tmp
 WORKDIR /app
 
 CMD ["composer"]
-RUN composer global require phpstan/phpstan ^0.11
+RUN composer global require phpstan/phpstan ^0.12
 ENTRYPOINT [ "php", "-d", "memory_limit=-1", "/tmp/vendor/bin/phpstan" ]
 ARG BUILD_DATE
 ARG VCS_REF

--- a/xdebug/Dockerfile
+++ b/xdebug/Dockerfile
@@ -1,35 +1,34 @@
 #
 # This is an automatically generated Dockerfile, do not change this!
 #
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/doctrine_proxies \
     && mkdir -p /usr/share/nginx/www/spenden.wikimedia.de/current/var/log \
     && chown -R www-data:www-data /usr/share/nginx/www/spenden.wikimedia.de/current/var
 
+# Installing php extensions
+# The following php extensions are assumed to be present: xml curl mbstring pdo_sqlite
 RUN apt-get update \
+	# regex library needed for PHP 7.4
+	&& apt-get install libonig-dev \
     # for intl
     && apt-get install -y libicu-dev \
-    # for curl
-    && apt-get install -y libcurl3-dev \
-    # for xml
-    && apt-get install -y libxml2-dev \
     # for konto_check
-    && apt-get install -y unzip libz-dev \
-    #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
-    && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
+	&& apt-get install -y unzip libz-dev \
+    && docker-php-ext-install -j$(nproc) intl pdo_mysql
 
 RUN docker-php-source extract \
     && cd /tmp \
-    && curl -Ls -o konto_check-6.08.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.08/konto_check-6.08.zip/download  \
+    && curl -Ls -o konto_check-6.11.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/6.11/konto_check-6.11.zip/download  \
     && unzip konto_check-*.zip \
-    && cd konto_check-6.08 \
+    && cd konto_check-6.11 \
     && cp blz.lut2f /etc/blz.lut \
     && unzip php.zip \
     && cd php \
-    && docker-php-ext-configure /tmp/konto_check-6.08/php \
-    && docker-php-ext-install /tmp/konto_check-6.08/php \
+    && docker-php-ext-configure /tmp/konto_check-6.11/php \
+    && docker-php-ext-install /tmp/konto_check-6.11/php \
     && docker-php-source delete \
     && rm -rf /tmp/konto_check-*
 
@@ -37,7 +36,7 @@ RUN apt-get install -y msmtp \
     && printf "account default\nhost mailhog\nport 1025\nauto_from on\n" > /etc/msmtprc
 
 COPY ./mailhog.ini /usr/local/etc/php/conf.d/mailhog.ini
-RUN pecl install xdebug-2.7.2 \
+RUN pecl install xdebug-2.9.3 \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Update to PHP 7.4
Update XDebug to 2.9
Update Kontocheck to 6.11
Update to composer 1.10
Update PHPStan to 0.12

Removed installation of PHP extensions that are already part of the official PHP image:
curl, mbstring, xml