### PR TITLE
Update dependencies, release 1.1.2

### DIFF
--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -35,7 +35,7 @@ RUN docker-php-source extract \
 RUN apt-get install -y git subversion mercurial bash patch make zip libzip-dev \
     && docker-php-ext-install -j$(nproc) zip
 
-COPY --from=composer:1.10.1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.5 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp

--- a/generate_dockerfiles.php
+++ b/generate_dockerfiles.php
@@ -2,9 +2,9 @@
 <?php
 
 $PHP_VERSION = "7.4";
-$XDEBUG_VERSION = "2.9.3";
+$XDEBUG_VERSION = "2.9.4";
 $KONTOCHECK_VERSION = "6.11";
-$COMPOSER_VERSION = "1.10.1";
+$COMPOSER_VERSION = "1.10.5";
 $PHPSTAN_VERSION = "^0.12";
 
 $headerTemplate = <<<HD

--- a/stan/Dockerfile
+++ b/stan/Dockerfile
@@ -35,7 +35,7 @@ RUN docker-php-source extract \
 RUN apt-get install -y git subversion mercurial bash patch make zip libzip-dev \
     && docker-php-ext-install -j$(nproc) zip
 
-COPY --from=composer:1.10.1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.5 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp

--- a/xdebug/Dockerfile
+++ b/xdebug/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get install -y msmtp \
     && printf "account default\nhost mailhog\nport 1025\nauto_from on\n" > /etc/msmtprc
 
 COPY ./mailhog.ini /usr/local/etc/php/conf.d/mailhog.ini
-RUN pecl install xdebug-2.9.3 \
+RUN pecl install xdebug-2.9.4 \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Update composer and xdebug

Release 1.1.1 does not have a commit, it was using an updated image of
PHP 7.4 but did not use the new composer and xdebug versions.