### PR TITLE
Always pull newest image when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,7 @@ do
   fi
   set -e
   docker build \
+	--pull \
     --build-arg VCS_REF=$VCS_REF \
     --build-arg BUILD_VERSION=$BUILD_VERSION \
     --build-arg BUILD_DATE=$BUILD_DATE \


### PR DESCRIPTION
Adding --pull to the `docker build` command in the script will reduce
user error (forgetting to pull before building). Pulling an already
current version does not generate network traffic and doesn't hurt the
build process.
